### PR TITLE
Hide loading overlay even if page is cached

### DIFF
--- a/_src/layout/js/scripts.js
+++ b/_src/layout/js/scripts.js
@@ -1,14 +1,16 @@
 $(document).ready(function(){
 
-// Use pace to fade in page content after load and fade out before leaving pages.
-Pace.on('start', function() {$('.module').css({'margin-top':'2em'});});
-Pace.on('done', function() {
+function siteLoaded () {
 	console.log("Site Loaded!");
 	$('.pace-progress').addClass('pace-done');
 	$('.module').css({'margin-top':'0'});
-	$('#pace-cover').fadeOut(250, function(){
-	});
-});
+	$('#pace-cover').fadeOut(250);
+}
+
+// Use pace to fade in page content after load and fade out before leaving pages.
+Pace.on('start', function() {$('.module').css({'margin-top':'2em'});});
+Pace.on('done', siteLoaded);
+$(window).on('pageshow', siteLoaded);
 
 $('a').each(function() {
 	var anchor = new RegExp('/' + window.location.host + '/');

--- a/layout/js/scripts.js
+++ b/layout/js/scripts.js
@@ -1,14 +1,16 @@
 $(document).ready(function(){
 
-// Use pace to fade in page content after load and fade out before leaving pages.
-Pace.on('start', function() {$('.module').css({'margin-top':'2em'});});
-Pace.on('done', function() {
+function siteLoaded () {
 	console.log("Site Loaded!");
 	$('.pace-progress').addClass('pace-done');
 	$('.module').css({'margin-top':'0'});
-	$('#pace-cover').fadeOut(250, function(){
-	});
-});
+	$('#pace-cover').fadeOut(250);
+}
+
+// Use pace to fade in page content after load and fade out before leaving pages.
+Pace.on('start', function() {$('.module').css({'margin-top':'2em'});});
+Pace.on('done', siteLoaded);
+$(window).on('pageshow', siteLoaded);
 
 $('a').each(function() {
 	var anchor = new RegExp('/' + window.location.host + '/');


### PR DESCRIPTION
Browsers, like Safari, display a cached version of a webpage when using the back button. The cached page never triggers the `Pace.done` event and the site's loading overlay is never hidden. Hiding the overlay on  `pageshow` will ensure that even cached pages display properly.