### PR TITLE
Update canonical URLs to include new https default

### DIFF
--- a/_src/layout/_header.ejs
+++ b/_src/layout/_header.ejs
@@ -7,9 +7,9 @@
 	<meta name="description" content="<%= pageDescription %>">
 	<meta name="author" content="Lake Afton Public Observatory">
 	<meta property="og:title" content="Lake Afton Public Observatory">
-	<meta property="og:url" content="http://www.lakeafton.com/">
+	<meta property="og:url" content="https://www.lakeafton.com/">
 	<meta property="og:type" content="website">
-	<meta property="og:image" content="http://www.lakeafton.com/layout/img/LAPO_OpenGraph.jpg">
+	<meta property="og:image" content="https://www.lakeafton.com/layout/img/LAPO_OpenGraph.jpg">
 	<meta property="og:description" content="Through our telescope, exhibits, and events, we aim to foster education and wonder about our solar system and beyond.">
 	<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=1, minimum-scale=0.1">
 	<meta name="format-detection" content="telephone=yes">

--- a/about/index.html
+++ b/about/index.html
@@ -7,9 +7,9 @@
 	<meta name="description" content="">
 	<meta name="author" content="Lake Afton Public Observatory">
 	<meta property="og:title" content="Lake Afton Public Observatory">
-	<meta property="og:url" content="http://www.lakeafton.com/">
+	<meta property="og:url" content="https://www.lakeafton.com/">
 	<meta property="og:type" content="website">
-	<meta property="og:image" content="http://www.lakeafton.com/layout/img/LAPO_OpenGraph.jpg">
+	<meta property="og:image" content="https://www.lakeafton.com/layout/img/LAPO_OpenGraph.jpg">
 	<meta property="og:description" content="Through our telescope, exhibits, and events, we aim to foster education and wonder about our solar system and beyond.">
 	<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=1, minimum-scale=0.1">
 	<meta name="format-detection" content="telephone=yes">

--- a/calendar/index.html
+++ b/calendar/index.html
@@ -7,9 +7,9 @@
 	<meta name="description" content="">
 	<meta name="author" content="Lake Afton Public Observatory">
 	<meta property="og:title" content="Lake Afton Public Observatory">
-	<meta property="og:url" content="http://www.lakeafton.com/">
+	<meta property="og:url" content="https://www.lakeafton.com/">
 	<meta property="og:type" content="website">
-	<meta property="og:image" content="http://www.lakeafton.com/layout/img/LAPO_OpenGraph.jpg">
+	<meta property="og:image" content="https://www.lakeafton.com/layout/img/LAPO_OpenGraph.jpg">
 	<meta property="og:description" content="Through our telescope, exhibits, and events, we aim to foster education and wonder about our solar system and beyond.">
 	<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=1, minimum-scale=0.1">
 	<meta name="format-detection" content="telephone=yes">

--- a/contact/index.html
+++ b/contact/index.html
@@ -7,9 +7,9 @@
 	<meta name="description" content="">
 	<meta name="author" content="Lake Afton Public Observatory">
 	<meta property="og:title" content="Lake Afton Public Observatory">
-	<meta property="og:url" content="http://www.lakeafton.com/">
+	<meta property="og:url" content="https://www.lakeafton.com/">
 	<meta property="og:type" content="website">
-	<meta property="og:image" content="http://www.lakeafton.com/layout/img/LAPO_OpenGraph.jpg">
+	<meta property="og:image" content="https://www.lakeafton.com/layout/img/LAPO_OpenGraph.jpg">
 	<meta property="og:description" content="Through our telescope, exhibits, and events, we aim to foster education and wonder about our solar system and beyond.">
 	<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=1, minimum-scale=0.1">
 	<meta name="format-detection" content="telephone=yes">

--- a/index.html
+++ b/index.html
@@ -7,9 +7,9 @@
 	<meta name="description" content="">
 	<meta name="author" content="Lake Afton Public Observatory">
 	<meta property="og:title" content="Lake Afton Public Observatory">
-	<meta property="og:url" content="http://www.lakeafton.com/">
+	<meta property="og:url" content="https://www.lakeafton.com/">
 	<meta property="og:type" content="website">
-	<meta property="og:image" content="http://www.lakeafton.com/layout/img/LAPO_OpenGraph.jpg">
+	<meta property="og:image" content="https://www.lakeafton.com/layout/img/LAPO_OpenGraph.jpg">
 	<meta property="og:description" content="Through our telescope, exhibits, and events, we aim to foster education and wonder about our solar system and beyond.">
 	<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=1, minimum-scale=0.1">
 	<meta name="format-detection" content="telephone=yes">

--- a/news/index.html
+++ b/news/index.html
@@ -7,9 +7,9 @@
 	<meta name="description" content="">
 	<meta name="author" content="Lake Afton Public Observatory">
 	<meta property="og:title" content="Lake Afton Public Observatory">
-	<meta property="og:url" content="http://www.lakeafton.com/">
+	<meta property="og:url" content="https://www.lakeafton.com/">
 	<meta property="og:type" content="website">
-	<meta property="og:image" content="http://www.lakeafton.com/layout/img/LAPO_OpenGraph.jpg">
+	<meta property="og:image" content="https://www.lakeafton.com/layout/img/LAPO_OpenGraph.jpg">
 	<meta property="og:description" content="Through our telescope, exhibits, and events, we aim to foster education and wonder about our solar system and beyond.">
 	<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=1, minimum-scale=0.1">
 	<meta name="format-detection" content="telephone=yes">

--- a/resources/index.html
+++ b/resources/index.html
@@ -7,9 +7,9 @@
 	<meta name="description" content="">
 	<meta name="author" content="Lake Afton Public Observatory">
 	<meta property="og:title" content="Lake Afton Public Observatory">
-	<meta property="og:url" content="http://www.lakeafton.com/">
+	<meta property="og:url" content="https://www.lakeafton.com/">
 	<meta property="og:type" content="website">
-	<meta property="og:image" content="http://www.lakeafton.com/layout/img/LAPO_OpenGraph.jpg">
+	<meta property="og:image" content="https://www.lakeafton.com/layout/img/LAPO_OpenGraph.jpg">
 	<meta property="og:description" content="Through our telescope, exhibits, and events, we aim to foster education and wonder about our solar system and beyond.">
 	<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=1, minimum-scale=0.1">
 	<meta name="format-detection" content="telephone=yes">

--- a/who-we-are/index.html
+++ b/who-we-are/index.html
@@ -7,9 +7,9 @@
 	<meta name="description" content="">
 	<meta name="author" content="Lake Afton Public Observatory">
 	<meta property="og:title" content="Lake Afton Public Observatory">
-	<meta property="og:url" content="http://www.lakeafton.com/">
+	<meta property="og:url" content="https://www.lakeafton.com/">
 	<meta property="og:type" content="website">
-	<meta property="og:image" content="http://www.lakeafton.com/layout/img/LAPO_OpenGraph.jpg">
+	<meta property="og:image" content="https://www.lakeafton.com/layout/img/LAPO_OpenGraph.jpg">
 	<meta property="og:description" content="Through our telescope, exhibits, and events, we aim to foster education and wonder about our solar system and beyond.">
 	<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=1, minimum-scale=0.1">
 	<meta name="format-detection" content="telephone=yes">


### PR DESCRIPTION
SSL certs have been installed for the website from letsencrypt.org using Certbot (https://certbot.eff.org/#ubuntuxenial-nginx)

I've updated the canonical URLs to reflect this.